### PR TITLE
Fix usage of config file when it is not in the project root

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -179,8 +179,8 @@ function runDjlint(
     let stdout = "";
     let stderr = "";
     const childArgs = pythonExec[1].concat(["-m", "djlint", "-"]).concat(args);
-    const cwd = vscode.workspace.getWorkspaceFolder(document.uri);
-    const childOptions = cwd ? { cwd: cwd.uri.fsPath } : undefined;
+    const cwd = vscode.Uri.joinPath(document.uri, "../");
+    const childOptions = cwd ? { cwd: cwd.fsPath } : undefined;
     const child = spawn(pythonExec[0], childArgs, childOptions);
     child.stdin.write(document.getText());
     child.stdin.end();


### PR DESCRIPTION
Changed cwd from the vs project root to the current file's dir to allow djlint to find an upstream settings file from the current file. closes #81

It can be tested w/ this:

![image](https://user-images.githubusercontent.com/17788706/195591778-75918eee-7ba0-45af-9247-a710983b66ae.png)

pyproject.toml contents:
```toml
[tool.djlint]
indent=3
```